### PR TITLE
Inline lexer must pass encode argument to escape()

### DIFF
--- a/lib/kramed.js
+++ b/lib/kramed.js
@@ -599,12 +599,12 @@ InlineLexer.output = function(src, links, options) {
   return inline.output(src);
 };
 
-InlineLexer.prototype.escape = function(html) {
+InlineLexer.prototype.escape = function(html, encode) {
   // Handle escaping being turned off
   if(this.options && this.options.escape === false) {
     return html;
   }
-  return escape(html);
+  return escape(html, encode);
 };
 
 /**


### PR DESCRIPTION
The the escape method for InlineLexer did not take a second argument.  The escape method underlying it accepts this argument.  For certain things like inline code, this argument needs to be passed for things to work as expected (e.g. inline code should have `&` escaped).
